### PR TITLE
Fix camel to snake case

### DIFF
--- a/src/parse_idl.rs
+++ b/src/parse_idl.rs
@@ -504,6 +504,7 @@ fn parse_raw_schema_type(name: &str) -> SchemaType {
 
 #[cfg(test)]
 mod test {
+    use super::camel_to_snake_case;
     use solana_program::hash::hash;
 
     #[test]
@@ -512,5 +513,17 @@ mod test {
         println!("{:x}", u64::from_be_bytes(b[..8].try_into().unwrap()));
         let a = hash(&format!("account:{}", "State").into_bytes()).to_bytes();
         println!("{:x}", u64::from_be_bytes(a[..8].try_into().unwrap()));
+    }
+
+    #[test]
+    fn test_camel_to_snake_case() {
+        assert_eq!(camel_to_snake_case("mintV1"), "mint_v1");
+        assert_eq!(camel_to_snake_case("CreateTree"), "create_tree");
+        assert_eq!(camel_to_snake_case("CancelRedeem"), "cancel_redeem");
+        assert_eq!(
+            camel_to_snake_case("NFTMetadataUpdate"),
+            "nft_metadata_update"
+        );
+        assert_eq!(camel_to_snake_case("doAbc123"), "do_abc123");
     }
 }

--- a/src/parse_idl.rs
+++ b/src/parse_idl.rs
@@ -282,7 +282,11 @@ fn camel_to_snake_case(s: &str) -> String {
 
     while let Some(c) = chars.next() {
         if c.is_uppercase() {
-            if !result.is_empty() && chars.peek().map_or(false, |next| next.is_lowercase()) {
+            if !result.is_empty()
+                && chars
+                    .peek()
+                    .map_or(false, |next| next.is_lowercase() || next.is_ascii_digit())
+            {
                 result.push('_');
             }
             result.push(c.to_lowercase().next().unwrap());


### PR DESCRIPTION
Problem

The camel_to_snake_case utility failed to correctly convert instruction names with digit suffixes like mintV1. It inserted an unnecessary underscore:
mintV1 → mint_v_1 instead of the expected mint_v1 .
This broke discriminator hashing for some Bubblegum instructions like mintV1, causing "Instruction discriminant not found" errors during parsing.

Solution

Fixed the condition in camel_to_snake_case to treat digits as valid trailing characters after an uppercase letter.
Added a test suite to ensure correct conversion of instruction names.